### PR TITLE
Clearer output message

### DIFF
--- a/post-checkout
+++ b/post-checkout
@@ -50,4 +50,4 @@ fi
 git config --local user.email "$email"
 git config --local user.name "$name"
 
-echo -e "\nIdentity set to $name <$email>"
+echo -e "\nLocal identity for ${PWD##*/} set to \"$name <$email>\""


### PR DESCRIPTION
Making the final output message more clear that its setting a local config, in what directory (repo name), and quoting the name and email.