### PR TITLE
Make post-checkout set up author.email/name as well

### DIFF
--- a/post-checkout
+++ b/post-checkout
@@ -49,5 +49,7 @@ fi
 
 git config --local user.email "$email"
 git config --local user.name "$name"
+git config --local author.email "$email"
+git config --local author.name "$name"
 
 echo -e "\nLocal identity for ${PWD##*/} set to \"$name <$email>\""


### PR DESCRIPTION
If a user has set up both user.email/name and author.email/name in a global ~/.gitconfig, git will default to the global author.email/name when adding commits to a project automatically set up with git-clone-init